### PR TITLE
Handle HiDPI

### DIFF
--- a/plasmoid/contents/ui/main.qml
+++ b/plasmoid/contents/ui/main.qml
@@ -214,9 +214,9 @@ Rectangle {
                     dataName=data.name.split(' ')[1];
 
                 if (coreTempModel.count <= dataName)
-                    coreTempModel.append({'val':data.value, 'units':data.units});
+                    coreTempModel.append({'val':data.value, 'dataUnits':data.units});
                 else
-                    coreTempModel.set(dataName,{'val':data.value, 'units':data.units});
+                    coreTempModel.set(dataName,{'val':data.value, 'dataUnits':data.units});
 
                 return;
             }

--- a/plasmoid/contents/ui/monitorWidgets/CoreTempList.qml
+++ b/plasmoid/contents/ui/monitorWidgets/CoreTempList.qml
@@ -26,8 +26,8 @@ ListView {
     LayoutMirroring.enabled: direction === Qt.RightToLeft
     LayoutMirroring.childrenInherit: true
 
-    implicitHeight: count * 25
-    implicitWidth: 100
+    implicitHeight: count * 25 * units.devicePixelRatio
+    implicitWidth: 100 * units.devicePixelRatio
 
     interactive: false
 
@@ -40,7 +40,7 @@ ListView {
 
     delegate: Item {
         id: coreListTemp
-        implicitHeight: 25
+        implicitHeight: 25 * units.devicePixelRatio
         implicitWidth: coreLabel.implicitWidth + unitLabel.implicitWidth
         width: parent.width
         Text {
@@ -53,7 +53,7 @@ ListView {
         }
         Text {
             id: unitLabel
-            text: if (tempUnit === 0) Math.floor(val) + units
+            text: if (tempUnit === 0) Math.floor(val) + dataUnits
                   else Math.floor(val*9/5+32) + "°F"
             font.bold: true
             font.pointSize: 10
@@ -63,18 +63,18 @@ ListView {
 
         Rectangle {
             id: rectValue
-            height: 9
+            height: 11 * units.devicePixelRatio
             width: Math.floor(val/coreTempList.criticalTemp*parent.width)
             color: if (val >= coreTempList.criticalTemp) "red"
                    else if (val >= coreTempList.highTemp) "#ffac2a"
                    else "#85a9ff"
             anchors.top: coreLabel.bottom
             anchors.right: parent.right
-            anchors.topMargin: 1
+            anchors.topMargin: units.devicePixelRatio
         }
         ListView.onAdd: SequentialAnimation {
             PropertyAction { target: coreListTemp; property: "height"; value: 0 }
-            NumberAnimation { target: coreListTemp; property: "height"; to: 25; duration: 250; easing.type: Easing.InOutQuad }
+            NumberAnimation { target: coreListTemp; property: "height"; to: 30 * units.devicePixelRatio; duration: 250; easing.type: Easing.InOutQuad }
         }
     }
 

--- a/plasmoid/contents/ui/monitorWidgets/CpuWidget.qml
+++ b/plasmoid/contents/ui/monitorWidgets/CpuWidget.qml
@@ -28,7 +28,7 @@ ListView {
 
     property color progressColor: "#993de515"
 
-    implicitWidth: 100
+    implicitWidth: 100 * units.devicePixelRatio
     implicitHeight: childrenRect.height
 
     model: cpuModel
@@ -46,12 +46,12 @@ ListView {
     delegate: Item {
         id: itemElement
         width: cpuListView.width
-        height: cpuListItem.height + 1
+        height: cpuListItem.height + units.devicePixelRatio
         Column {
             id: cpuListItem
             width: parent.width
             Row {
-                spacing: 5
+                spacing: 5 * units.devicePixelRatio
                 anchors.left: parent.left
                 Text {
                     id: cpuLabel
@@ -69,7 +69,7 @@ ListView {
             }
             Item {
                 id: progressBar
-                height: 8
+                height: 10 * units.devicePixelRatio
                 //clip: true
                 width: parent.width
                 Rectangle {
@@ -160,9 +160,9 @@ ListView {
                     }
                 }
                 Rectangle {
-                    height: progressBar.height+4
-                    width: 5
-                    radius: 2
+                    height: progressBar.height + 4 * units.devicePixelRatio
+                    width: 5 * units.devicePixelRatio
+                    radius: 2 * units.devicePixelRatio
                     anchors.left: rectValue.right
                     anchors.verticalCenter: parent.verticalCenter
                     color: "#88ffffff"
@@ -183,7 +183,7 @@ ListView {
 
         ListView.onAdd: SequentialAnimation {
             PropertyAction { target: cpuListItem; property: "height"; value: 0 }
-            NumberAnimation { target: cpuListItem; property: "height"; to: 25; duration: 250; easing.type: Easing.InOutQuad }
+            NumberAnimation { target: cpuListItem; property: "height"; to: 30 * units.devicePixelRatio; duration: 250; easing.type: Easing.InOutQuad }
         }
     }
 

--- a/plasmoid/contents/ui/monitorWidgets/MemArea.qml
+++ b/plasmoid/contents/ui/monitorWidgets/MemArea.qml
@@ -39,11 +39,11 @@ Item {
     ColumnLayout {
         id: memColumn
 
-        spacing: 2
+        spacing: 2 * units.devicePixelRatio
         anchors.fill: parent
 
         RowLayout {
-            spacing: 3
+            spacing: 3 * units.devicePixelRatio
             Text {
                 id: memType
                 text: i18n("Mem:")
@@ -59,7 +59,7 @@ Item {
 
         RowLayout {
             id: memoryInfoLabels
-            spacing: 3
+            spacing: 3 * units.devicePixelRatio
             property int fontSize : 8
             Text {
                 text: i18n("Used:")
@@ -87,7 +87,7 @@ Item {
 
         Rectangle {
             id: rectTotalMemory
-            height: 5
+            height: 7 * units.devicePixelRatio
             Layout.fillWidth: true
             color: "#7ec264"
             Rectangle {

--- a/plasmoid/contents/ui/monitorWidgets/TimePicker.qml
+++ b/plasmoid/contents/ui/monitorWidgets/TimePicker.qml
@@ -26,7 +26,7 @@ Item {
     LayoutMirroring.childrenInherit: true
 
     implicitWidth: secs.x + secs.width
-    implicitHeight: hour.implicitHeight - 11
+    implicitHeight: hour.implicitHeight - 11 * units.devicePixelRatio
 
     FontLoader {
         id: playRegular
@@ -50,7 +50,7 @@ Item {
         id: hour
         anchors.left: parent.left
         anchors.bottom: parent.bottom
-        height: 44
+        height: 44 * units.devicePixelRatio
         text: "00:"
         font {
             family: playRegular.name
@@ -62,7 +62,7 @@ Item {
         id: mins
         anchors.left: hour.right
         anchors.bottom: parent.bottom
-        height: 29
+        height: 29 * units.devicePixelRatio
         text: "00:"
         font {
             family: playRegular.name
@@ -74,7 +74,7 @@ Item {
         id: secs
         anchors.left: mins.right
         anchors.bottom: parent.bottom
-        height: 21
+        height: 21 * units.devicePixelRatio
         text: "00"
         font {
             family: playRegular.name

--- a/plasmoid/contents/ui/monitorWidgets/UptimePicker.qml
+++ b/plasmoid/contents/ui/monitorWidgets/UptimePicker.qml
@@ -22,7 +22,7 @@ import QtQuick 2.0
 Row {
     property int uptime: 0
 
-    spacing: 3
+    spacing: 3 * units.devicePixelRatio
 
     QtObject {
         id: d

--- a/plasmoid/contents/ui/skins/ColumnSkin.qml
+++ b/plasmoid/contents/ui/skins/ColumnSkin.qml
@@ -39,7 +39,7 @@ BaseSkin {
         id: mainLayout
 
         anchors.fill: parent
-        anchors.margins: 5
+        anchors.margins: 5 * units.devicePixelRatio
         spacing: 0
 
         Item {
@@ -72,7 +72,7 @@ BaseSkin {
             rowSpacing: 0
 
             Layout.fillWidth: true
-            Layout.topMargin: 5
+            Layout.topMargin: 5 * units.devicePixelRatio
 
             ColumnLayout {
                 id: distroInfo
@@ -87,8 +87,8 @@ BaseSkin {
 
                 LogoImage {
                     id: distroLogo
-                    Layout.minimumWidth: (implicitWidth < implicitHeight) ? 100*implicitWidth/implicitHeight : 100
-                    Layout.minimumHeight: (implicitHeight < implicitWidth) ? 100*implicitHeight/implicitWidth : 100
+                    Layout.minimumWidth: (implicitWidth < implicitHeight) ? 100*implicitWidth/implicitHeight : 100 * units.devicePixelRatio
+                    Layout.minimumHeight: (implicitHeight < implicitWidth) ? 100*implicitHeight/implicitWidth : 100 * units.devicePixelRatio
                     Layout.preferredWidth: (Layout.fillWidth) ? Layout.minimumWidth : height * implicitWidth/implicitHeight
                     Layout.preferredHeight: (Layout.fillHeight) ? Layout.minimumHeight : width * implicitHeight/implicitWidth
                     Layout.fillWidth: (implicitWidth < implicitHeight) ? false: true
@@ -126,7 +126,7 @@ BaseSkin {
                     kernelVersion: root.kernelVersion
 
                     Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
-                    Layout.topMargin: 2
+                    Layout.topMargin: 2 * units.devicePixelRatio
                     Layout.minimumHeight: implicitHeight
                     Layout.maximumHeight: implicitHeight
                     Layout.minimumWidth: implicitWidth
@@ -139,9 +139,9 @@ BaseSkin {
                 id: timePicker
 
                 Layout.alignment: Qt.AlignLeft
-                Layout.topMargin: -5
-                Layout.leftMargin: 10
-                Layout.bottomMargin: 5
+                Layout.topMargin: -5 * units.devicePixelRatio
+                Layout.leftMargin: 10 * units.devicePixelRatio
+                Layout.bottomMargin: 5 * units.devicePixelRatio
                 Layout.minimumHeight: implicitHeight
                 Layout.maximumHeight: implicitHeight
                 Layout.preferredWidth: implicitWidth
@@ -153,9 +153,9 @@ BaseSkin {
 
                 Layout.leftMargin: 2
                 Layout.fillWidth: true
-                Layout.minimumHeight: 3
-                Layout.maximumHeight: 3
-                Layout.preferredHeight: 3
+                Layout.minimumHeight: 3 * units.devicePixelRatio
+                Layout.maximumHeight: 3 * units.devicePixelRatio
+                Layout.preferredHeight: 3 * units.devicePixelRatio
             }
 
             CoreTempList {
@@ -167,9 +167,9 @@ BaseSkin {
                 tempUnit: root.tempUnit
                 direction: root.direction
 
-                Layout.leftMargin: 5
-                Layout.rightMargin: 5
-                Layout.topMargin: 5
+                Layout.leftMargin: 5 * units.devicePixelRatio
+                Layout.rightMargin: 5 * units.devicePixelRatio
+                Layout.topMargin: 5 * units.devicePixelRatio
                 Layout.fillWidth: true
                 Layout.fillHeight: true
                 Layout.minimumWidth: implicitWidth
@@ -183,10 +183,10 @@ BaseSkin {
             color: "white"
 
             Layout.fillWidth: true
-            Layout.minimumHeight: 3
-            Layout.maximumHeight: 3
-            Layout.preferredHeight: 3
-            Layout.topMargin: 5
+            Layout.minimumHeight: 3 * units.devicePixelRatio
+            Layout.maximumHeight: 3 * units.devicePixelRatio
+            Layout.preferredHeight: 3 * units.devicePixelRatio
+            Layout.topMargin: 5 * units.devicePixelRatio
         }
 
         CpuWidget {
@@ -194,8 +194,8 @@ BaseSkin {
 
             direction: root.direction
 
-            Layout.leftMargin: 5
-            Layout.topMargin: 5
+            Layout.leftMargin: 5 * units.devicePixelRatio
+            Layout.topMargin: 5 * units.devicePixelRatio
             Layout.fillWidth: true
             Layout.minimumWidth: implicitWidth
             Layout.minimumHeight: implicitHeight
@@ -207,10 +207,10 @@ BaseSkin {
             color: "white"
 
             Layout.fillWidth: true
-            Layout.minimumHeight: 3
-            Layout.maximumHeight: 3
-            Layout.preferredHeight: 3
-            Layout.topMargin: 5
+            Layout.minimumHeight: 3 * units.devicePixelRatio
+            Layout.maximumHeight: 3 * units.devicePixelRatio
+            Layout.preferredHeight: 3 * units.devicePixelRatio
+            Layout.topMargin: 5 * units.devicePixelRatio
         }
 
         MemArea {
@@ -223,9 +223,9 @@ BaseSkin {
             memBuffers: root.memBuffers
 
             Layout.columnSpan: 2
-            Layout.topMargin: 2
-            Layout.leftMargin: 10
-            Layout.rightMargin: 5
+            Layout.topMargin: 2 * units.devicePixelRatio
+            Layout.leftMargin: 10 * units.devicePixelRatio
+            Layout.rightMargin: 5 * units.devicePixelRatio
             Layout.fillWidth: true
             Layout.minimumWidth: implicitWidth
             Layout.minimumHeight: implicitHeight
@@ -238,10 +238,10 @@ BaseSkin {
             color: "white"
 
             Layout.fillWidth: true
-            Layout.minimumHeight: 3
-            Layout.maximumHeight: 3
-            Layout.preferredHeight: 3
-            Layout.topMargin: 5
+            Layout.minimumHeight: 3 * units.devicePixelRatio
+            Layout.maximumHeight: 3 * units.devicePixelRatio
+            Layout.preferredHeight: 3 * units.devicePixelRatio
+            Layout.topMargin: 5 * units.devicePixelRatio
         }
 
         MemArea {
@@ -254,9 +254,9 @@ BaseSkin {
             memUsed: root.swapUsed
 
             Layout.columnSpan: 2
-            Layout.topMargin: 2
-            Layout.leftMargin: 10
-            Layout.rightMargin: 5
+            Layout.topMargin: 2 * units.devicePixelRatio
+            Layout.leftMargin: 10 * units.devicePixelRatio
+            Layout.rightMargin: 5 * units.devicePixelRatio
             Layout.fillWidth: true
             Layout.minimumWidth: implicitWidth
             Layout.minimumHeight: implicitHeight

--- a/plasmoid/contents/ui/skins/DefaultSkin.qml
+++ b/plasmoid/contents/ui/skins/DefaultSkin.qml
@@ -35,7 +35,7 @@ BaseSkin {
         id: mainLayout
 
         anchors.fill: parent
-        anchors.margins: 5
+        anchors.margins: 5 * units.devicePixelRatio
         columns: 4
         rows: 8
         columnSpacing: 0
@@ -46,7 +46,7 @@ BaseSkin {
 
             Layout.columnSpan: 4
             Layout.alignment: Qt.AlignLeft
-            Layout.leftMargin: 10
+            Layout.leftMargin: 10 * units.devicePixelRatio
             Layout.minimumWidth: implicitWidth
             Layout.minimumHeight: implicitHeight
             Layout.maximumHeight: implicitHeight
@@ -56,7 +56,7 @@ BaseSkin {
             id: distroInfo
 
             Layout.rowSpan: 3
-            Layout.topMargin: 5
+            Layout.topMargin: 5 * units.devicePixelRatio
             Layout.fillWidth: true
             Layout.fillHeight: true
             Layout.minimumWidth: implicitWidth
@@ -66,8 +66,8 @@ BaseSkin {
 
             LogoImage {
                 id: distroLogo
-                Layout.minimumWidth: (implicitWidth < implicitHeight) ? 100*implicitWidth/implicitHeight : 100
-                Layout.minimumHeight: (implicitHeight < implicitWidth) ? 100*implicitHeight/implicitWidth : 100
+                Layout.minimumWidth: (implicitWidth < implicitHeight) ? 100*implicitWidth/implicitHeight : 100 * units.devicePixelRatio
+                Layout.minimumHeight: (implicitHeight < implicitWidth) ? 100*implicitHeight/implicitWidth : 100 * units.devicePixelRatio
                 Layout.preferredWidth: (Layout.fillWidth) ? Layout.minimumWidth : height * implicitWidth/implicitHeight
                 Layout.preferredHeight: (Layout.fillHeight) ? Layout.minimumHeight : width * implicitHeight/implicitWidth
                 Layout.fillWidth: (implicitWidth < implicitHeight) ? false: true
@@ -105,7 +105,7 @@ BaseSkin {
                 kernelVersion: root.kernelVersion
 
                 Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
-                Layout.topMargin: 2
+                Layout.topMargin: 2 * units.devicePixelRatio
                 Layout.minimumHeight: implicitHeight
                 Layout.maximumHeight: implicitHeight
                 Layout.minimumWidth: implicitWidth
@@ -119,8 +119,8 @@ BaseSkin {
 
             Layout.columnSpan: 2
             Layout.alignment: Qt.AlignLeft
-            Layout.leftMargin: 10
-            Layout.bottomMargin: 5
+            Layout.leftMargin: 10 * units.devicePixelRatio
+            Layout.bottomMargin: 5 * units.devicePixelRatio
             Layout.minimumHeight: implicitHeight
             Layout.maximumHeight: implicitHeight
             Layout.preferredWidth: implicitWidth
@@ -134,7 +134,7 @@ BaseSkin {
             uptime: root.uptime
 
             Layout.alignment: Qt.AlignRight | Qt.AlignBottom
-            Layout.bottomMargin: 2
+            Layout.bottomMargin: 2 * units.devicePixelRatio
             Layout.minimumHeight: height
             Layout.preferredWidth: implicitWidth
             Layout.preferredHeight: implicitHeight
@@ -145,10 +145,10 @@ BaseSkin {
 
             Layout.columnSpan: 3
             Layout.fillWidth: true
-            Layout.minimumHeight: 3
-            Layout.maximumHeight: 3
-            Layout.preferredHeight: 3
-            Layout.leftMargin: 2
+            Layout.minimumHeight: 3 * units.devicePixelRatio
+            Layout.maximumHeight: 3 * units.devicePixelRatio
+            Layout.preferredHeight: 3 * units.devicePixelRatio
+            Layout.leftMargin: 2 * units.devicePixelRatio
         }
 
         CoreTempList {
@@ -160,9 +160,9 @@ BaseSkin {
             tempUnit: root.tempUnit
             direction: root.direction
 
-            Layout.leftMargin: 5
-            Layout.rightMargin: 5
-            Layout.topMargin: 5
+            Layout.leftMargin: 5 * units.devicePixelRatio
+            Layout.rightMargin: 5 * units.devicePixelRatio
+            Layout.topMargin: 5 * units.devicePixelRatio
             Layout.fillWidth: true
             Layout.fillHeight: true
             Layout.minimumWidth: implicitWidth
@@ -175,11 +175,11 @@ BaseSkin {
             color: "white"
 
             Layout.rowSpan: 5
-            Layout.minimumWidth: 3
-            Layout.maximumWidth: 3
-            Layout.preferredWidth: 3
+            Layout.minimumWidth: 3 * units.devicePixelRatio
+            Layout.maximumWidth: 3 * units.devicePixelRatio
+            Layout.preferredWidth: 3 * units.devicePixelRatio
             Layout.fillHeight: true
-            Layout.topMargin: 5
+            Layout.topMargin: 5 * units.devicePixelRatio
         }
 
         CpuWidget {
@@ -188,8 +188,8 @@ BaseSkin {
             direction: root.direction
 
             Layout.rowSpan: 5
-            Layout.leftMargin: 5
-            Layout.topMargin: 5
+            Layout.leftMargin: 5 * units.devicePixelRatio
+            Layout.topMargin: 5 * units.devicePixelRatio
             Layout.fillWidth: true
             Layout.fillHeight: true
             Layout.minimumWidth: implicitWidth
@@ -203,11 +203,11 @@ BaseSkin {
 
             Layout.columnSpan: 2
             Layout.fillWidth: true
-            Layout.minimumHeight: 3
-            Layout.maximumHeight: 3
-            Layout.preferredHeight: 3
-            Layout.topMargin: 5
-            Layout.rightMargin: 5
+            Layout.minimumHeight: 3 * units.devicePixelRatio
+            Layout.maximumHeight: 3 * units.devicePixelRatio
+            Layout.preferredHeight: 3 * units.devicePixelRatio
+            Layout.topMargin: 5 * units.devicePixelRatio
+            Layout.rightMargin: 5 * units.devicePixelRatio
         }
 
         MemArea {
@@ -220,9 +220,9 @@ BaseSkin {
             memBuffers: root.memBuffers
 
             Layout.columnSpan: 2
-            Layout.topMargin: 2
-            Layout.leftMargin: 10
-            Layout.rightMargin: 5
+            Layout.topMargin: 2 * units.devicePixelRatio
+            Layout.leftMargin: 10 * units.devicePixelRatio
+            Layout.rightMargin: 5 * units.devicePixelRatio
             Layout.fillWidth: true
             Layout.minimumWidth: implicitWidth
             Layout.minimumHeight: implicitHeight
@@ -236,11 +236,11 @@ BaseSkin {
 
             Layout.columnSpan: 2
             Layout.fillWidth: true
-            Layout.minimumHeight: 3
-            Layout.maximumHeight: 3
-            Layout.preferredHeight: 3
-            Layout.topMargin: 5
-            Layout.rightMargin: 5
+            Layout.minimumHeight: 3 * units.devicePixelRatio
+            Layout.maximumHeight: 3 * units.devicePixelRatio
+            Layout.preferredHeight: 3 * units.devicePixelRatio
+            Layout.topMargin: 5 * units.devicePixelRatio
+            Layout.rightMargin: 5 * units.devicePixelRatio
         }
 
         MemArea {
@@ -253,9 +253,9 @@ BaseSkin {
             memUsed: root.swapUsed
 
             Layout.columnSpan: 2
-            Layout.topMargin: 2
-            Layout.leftMargin: 10
-            Layout.rightMargin: 5
+            Layout.topMargin: 2 * units.devicePixelRatio
+            Layout.leftMargin: 10 * units.devicePixelRatio
+            Layout.rightMargin: 5 * units.devicePixelRatio
             Layout.fillWidth: true
             Layout.minimumWidth: implicitWidth
             Layout.minimumHeight: implicitHeight


### PR DESCRIPTION
Make the plasmoid independent from the screen DPI, multiplying hard-coded sizes by [units.devicePixelRatio](https://api.kde.org/frameworks/plasma-framework/html/classUnits.html#a3110859f508d63d1d1d6dd4dbd3a54f6).

Before (on a 28" 4k screen):
<img src="https://user-images.githubusercontent.com/8300317/46994985-0bf72780-d117-11e8-8812-5df099fb2c7f.png" width=300 />

After:
<img src="https://user-images.githubusercontent.com/8300317/46994987-0e598180-d117-11e8-9cbc-fa8a11371f00.png" width=300 />

<!--![screenshot_20181016_070248](https://user-images.githubusercontent.com/8300317/46994985-0bf72780-d117-11e8-8812-5df099fb2c7f.png)-->
<!--![screenshot_20181016_071022](https://user-images.githubusercontent.com/8300317/46994987-0e598180-d117-11e8-9cbc-fa8a11371f00.png)-->

