### PR TITLE
fixed temperature monitor support for AMD CPUs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ build
 *.dll
 *.exe
 *.plasmoid
+.idea/

--- a/plasmoid/contents/code/code.js
+++ b/plasmoid/contents/code/code.js
@@ -21,6 +21,20 @@
 
 var logos = ["tux", "slackware", "ubuntu", "kubuntu", "opensuse", "manjaro", "arch", "fedora"]
 
+var k10Cores = new Set();
+
+function k10CoreIndex(k10Core) {
+    k10Cores.add(k10Core);
+    let i = 0;
+    for(let item of k10Cores.values()) {
+        if(item == k10Core) {
+            return i;
+        }
+        ++i;
+    }
+    return -1;
+}
+
 function getStandardLogo(logoId, distroName) {
     if (typeof distroName === 'undefined')
         distroName = "tux"

--- a/plasmoid/contents/ui/main.qml
+++ b/plasmoid/contents/ui/main.qml
@@ -151,10 +151,11 @@ Rectangle {
                 connectSource(source);
                 return;
             }
-            if (source.match("^lmsensors/k\\d+temp-pci-.+/temp\\d+")) {
+            if (source.match("^lmsensors/k\\d+temp-pci-.+/.+")) {
                 /* if atk is present then not connect */
-                if (!root.atkPresent)
+                if (!root.atkPresent) {
                     connectSource(source);
+                }
                 return;
             }
             /* Some AMD sensors works better with atk data*/
@@ -162,7 +163,7 @@ Rectangle {
                 /* Remove k# temp sensors previously connected*/
                 if (!root.atkPresent) {
                     for (i in connectedSources) {
-                        if (i.match("^lmsensors/k\\d+temp-pci-.+/temp\\d+")) {
+                        if (i.match("^lmsensors/k\\d+temp-pci-.+/.+")) {
                             disconnectSource(i);
                             coreTempModel.clear();
                         }
@@ -205,13 +206,16 @@ Rectangle {
 
             // cpu temp
             if (sourceName.match("^lmsensors/coretemp-isa-\\d+/Core_\\d+")
-                    || sourceName.match("^lmsensors/k\\d+temp-pci-.+/temp\\d+")
+                    || sourceName.match("^lmsensors/k\\d+temp-pci-.+/.+")
                     || sourceName.match("^lmsensors/atk\\d+-acpi-\\d/CPU_Temperature")) {
                 var dataName = "0";
-                if (root.atkPresent)
+                if (root.atkPresent) {
                     dataName=sourceName.replace(/^lmsensors\/atk\\d+-acpi-/i,"").replace(/\/CPU_Temperature/i,"");
-                else
+                } else if(sourceName.match("^lmsensors/k10temp-pci-.+/.+")) {
+                    dataName = Code.k10CoreIndex(sourceName.replace(/^lmsensors\/k10temp-pci-/i,""));
+                } else {
                     dataName=data.name.split(' ')[1];
+                }
 
                 if (coreTempModel.count <= dataName)
                     coreTempModel.append({'val':data.value, 'units':data.units});


### PR DESCRIPTION
Fixed the regex for adding the source and updating the data, as it was not matching.
Also introduced a work-around for the coreTempModel, as the data.name (or parts of) in this case is neither numerical nor consecutive.

Example for such a source name on my system: "lmsensors/k10temp-pci-00c3/Tctl"