### PR TITLE
Fixed QML errors preventing the widget to be displayed properly (if at all)

### DIFF
--- a/plasmoid/contents/ui/main.qml
+++ b/plasmoid/contents/ui/main.qml
@@ -126,7 +126,7 @@ Rectangle {
             Code.getDistroInfo(function(info) {
                 distroName = info['name']
                 distroId = info['id']
-                distroVersion = info['version']
+                distroVersion = (info['version'] !== undefined)?info['version']:""
             }, this);
 
             Code.getKernelInfo(function(info){
@@ -226,7 +226,7 @@ Rectangle {
         onSourceAdded: tryAddSource(source)
 
         onNewData: {
-            if (data.value === undefined || delegate === undefined)
+            if (data.value === undefined || data.value == null || delegate === undefined || delegate == null)
                 return;
 
             // cpu load

--- a/plasmoid/contents/ui/monitorWidgets/CoreTempList.qml
+++ b/plasmoid/contents/ui/monitorWidgets/CoreTempList.qml
@@ -42,8 +42,7 @@ ListView {
     delegate: Item {
         id: coreListTemp
         implicitHeight: 25 * units.devicePixelRatio
-        implicitWidth: coreLabel.implicitWidth + unitLabel.implicitWidth
-        width: parent.width
+        width: coreTempList.width
         height: (20 + indicatorHeight) * units.devicePixelRatio
         Text {
             id: coreLabel

--- a/plasmoid/contents/ui/monitorWidgets/CpuWidget.qml
+++ b/plasmoid/contents/ui/monitorWidgets/CpuWidget.qml
@@ -52,7 +52,6 @@ ListView {
             width: parent.width
             height: (20 + indicatorHeight) * units.devicePixelRatio
             Row {
-                spacing: 0
                 spacing: 5 * units.devicePixelRatio
                 anchors.left: parent.left
                 Text {

--- a/plasmoid/contents/ui/skins/DefaultSkin.qml
+++ b/plasmoid/contents/ui/skins/DefaultSkin.qml
@@ -152,14 +152,8 @@ BaseSkin {
             Layout.leftMargin: 2 * units.devicePixelRatio
         }
 
-        GridLayout {
+        ColumnLayout {
             id: tempLayout
-
-            model: coreTempModel
-            highTemp: cpuHighTemp
-            criticalTemp: criticalTemp
-            tempUnit: root.tempUnit
-            direction: root.direction
 
             Layout.leftMargin: 5 * units.devicePixelRatio
             Layout.rightMargin: 5 * units.devicePixelRatio


### PR DESCRIPTION
On recent versions of QT/Plasma (and at least on my system), the widget would not display anything, and spam the log with error-messages such like:
> TypeError: Value is null and could not be converted to an object

or
> Property value set multiple times

or 
> Error: Cannot assign [undefined] to QString

This PR solves that.
